### PR TITLE
Changes to get it going on PostgreSQL 11.5/pgx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/sqlbunny/geo
+module github.com/vaefremov/geo
 
-go 1.12
-
-require github.com/kernelpayments/geo v0.0.0-20181015145115-9ec6c1aa3dbb // indirect
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/kernelpayments/geo v0.0.0-20181015145115-9ec6c1aa3dbb h1:u8X7BVk7rYSRcHaVpjYWZENC5cn4jEROBOW7YjjQfZ0=
-github.com/kernelpayments/geo v0.0.0-20181015145115-9ec6c1aa3dbb/go.mod h1:kZyVW2vEQXYagMonTy0LN9gyF6DFCJAx/ECl1heFido=

--- a/null/LineString.go
+++ b/null/LineString.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineString is a nullable geo.LineString.

--- a/null/LineStringM.go
+++ b/null/LineStringM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineStringM is a nullable geo.LineStringM.

--- a/null/LineStringMS.go
+++ b/null/LineStringMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineStringMS is a nullable geo.LineStringMS.

--- a/null/LineStringS.go
+++ b/null/LineStringS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineStringS is a nullable geo.LineStringS.

--- a/null/LineStringZ.go
+++ b/null/LineStringZ.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineStringZ is a nullable geo.LineStringZ.

--- a/null/LineStringZM.go
+++ b/null/LineStringZM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineStringZM is a nullable geo.LineStringZM.

--- a/null/LineStringZMS.go
+++ b/null/LineStringZMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineStringZMS is a nullable geo.LineStringZMS.

--- a/null/LineStringZS.go
+++ b/null/LineStringZS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // LineStringZS is a nullable geo.LineStringZS.

--- a/null/MultiLineString.go
+++ b/null/MultiLineString.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineString is a nullable geo.MultiLineString.

--- a/null/MultiLineStringM.go
+++ b/null/MultiLineStringM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineStringM is a nullable geo.MultiLineStringM.

--- a/null/MultiLineStringMS.go
+++ b/null/MultiLineStringMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineStringMS is a nullable geo.MultiLineStringMS.

--- a/null/MultiLineStringS.go
+++ b/null/MultiLineStringS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineStringS is a nullable geo.MultiLineStringS.

--- a/null/MultiLineStringZ.go
+++ b/null/MultiLineStringZ.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineStringZ is a nullable geo.MultiLineStringZ.

--- a/null/MultiLineStringZM.go
+++ b/null/MultiLineStringZM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineStringZM is a nullable geo.MultiLineStringZM.

--- a/null/MultiLineStringZMS.go
+++ b/null/MultiLineStringZMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineStringZMS is a nullable geo.MultiLineStringZMS.

--- a/null/MultiLineStringZS.go
+++ b/null/MultiLineStringZS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiLineStringZS is a nullable geo.MultiLineStringZS.

--- a/null/MultiPoint.go
+++ b/null/MultiPoint.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPoint is a nullable geo.MultiPoint.

--- a/null/MultiPointM.go
+++ b/null/MultiPointM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPointM is a nullable geo.MultiPointM.

--- a/null/MultiPointMS.go
+++ b/null/MultiPointMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPointMS is a nullable geo.MultiPointMS.

--- a/null/MultiPointS.go
+++ b/null/MultiPointS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPointS is a nullable geo.MultiPointS.

--- a/null/MultiPointZ.go
+++ b/null/MultiPointZ.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPointZ is a nullable geo.MultiPointZ.

--- a/null/MultiPointZM.go
+++ b/null/MultiPointZM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPointZM is a nullable geo.MultiPointZM.

--- a/null/MultiPointZMS.go
+++ b/null/MultiPointZMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPointZMS is a nullable geo.MultiPointZMS.

--- a/null/MultiPointZS.go
+++ b/null/MultiPointZS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPointZS is a nullable geo.MultiPointZS.

--- a/null/MultiPolygon.go
+++ b/null/MultiPolygon.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygon is a nullable geo.MultiPolygon.

--- a/null/MultiPolygonM.go
+++ b/null/MultiPolygonM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygonM is a nullable geo.MultiPolygonM.

--- a/null/MultiPolygonMS.go
+++ b/null/MultiPolygonMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygonMS is a nullable geo.MultiPolygonMS.

--- a/null/MultiPolygonS.go
+++ b/null/MultiPolygonS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygonS is a nullable geo.MultiPolygonS.

--- a/null/MultiPolygonZ.go
+++ b/null/MultiPolygonZ.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygonZ is a nullable geo.MultiPolygonZ.

--- a/null/MultiPolygonZM.go
+++ b/null/MultiPolygonZM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygonZM is a nullable geo.MultiPolygonZM.

--- a/null/MultiPolygonZMS.go
+++ b/null/MultiPolygonZMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygonZMS is a nullable geo.MultiPolygonZMS.

--- a/null/MultiPolygonZS.go
+++ b/null/MultiPolygonZS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // MultiPolygonZS is a nullable geo.MultiPolygonZS.

--- a/null/Point.go
+++ b/null/Point.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // Point is a nullable geo.Point.

--- a/null/PointM.go
+++ b/null/PointM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PointM is a nullable geo.PointM.

--- a/null/PointMS.go
+++ b/null/PointMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PointMS is a nullable geo.PointMS.

--- a/null/PointS.go
+++ b/null/PointS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PointS is a nullable geo.PointS.

--- a/null/PointZ.go
+++ b/null/PointZ.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PointZ is a nullable geo.PointZ.

--- a/null/PointZM.go
+++ b/null/PointZM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PointZM is a nullable geo.PointZM.

--- a/null/PointZMS.go
+++ b/null/PointZMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PointZMS is a nullable geo.PointZMS.

--- a/null/PointZS.go
+++ b/null/PointZS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PointZS is a nullable geo.PointZS.

--- a/null/Polygon.go
+++ b/null/Polygon.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // Polygon is a nullable geo.Polygon.

--- a/null/PolygonM.go
+++ b/null/PolygonM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PolygonM is a nullable geo.PolygonM.

--- a/null/PolygonMS.go
+++ b/null/PolygonMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PolygonMS is a nullable geo.PolygonMS.

--- a/null/PolygonS.go
+++ b/null/PolygonS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PolygonS is a nullable geo.PolygonS.

--- a/null/PolygonZ.go
+++ b/null/PolygonZ.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PolygonZ is a nullable geo.PolygonZ.

--- a/null/PolygonZM.go
+++ b/null/PolygonZM.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PolygonZM is a nullable geo.PolygonZM.

--- a/null/PolygonZMS.go
+++ b/null/PolygonZMS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PolygonZMS is a nullable geo.PolygonZMS.

--- a/null/PolygonZS.go
+++ b/null/PolygonZS.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // PolygonZS is a nullable geo.PolygonZS.

--- a/null/template.txt
+++ b/null/template.txt
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/sqlbunny/geo"
+	"github.com/vaefremov/geo"
 )
 
 // $$$ is a nullable geo.$$$.

--- a/sql.go
+++ b/sql.go
@@ -14,6 +14,8 @@ func scan(value interface{}, g geom) (err error) {
 		_, err = hex.Decode(data, value.([]byte))
 	case string:
 		data, err = hex.DecodeString(value.(string))
+	case nil:
+		return errors.New("EWKB scan: use null package members to process NULLs")
 	default:
 		return errors.New("EWKB scan: value is neither byte slice nor string")
 	}

--- a/sql.go
+++ b/sql.go
@@ -6,17 +6,20 @@ import (
 	"errors"
 )
 
-func scan(value interface{}, g geom) error {
-	b, ok := value.([]byte)
-	if !ok {
-		return errors.New("EWKB scan: value is not byte slice")
+func scan(value interface{}, g geom) (err error) {
+	var data []byte
+	switch value.(type) {
+	case []byte:
+		data = make([]byte, len(value.([]byte)))
+		_, err = hex.Decode(data, value.([]byte))
+	case string:
+		data, err = hex.DecodeString(value.(string))
+	default:
+		return errors.New("EWKB scan: value is neither byte slice nor string")
 	}
-
-	data, err := hex.DecodeString(string(b))
 	if err != nil {
 		return err
 	}
-
 	return Unmarshal(data, g)
 }
 


### PR DESCRIPTION
It turns out that in my case PostgreSQL driver calls Scan with string argument representing PostGIS entity in hex encoding. So, the original version failed with the "EWKB scan: value is not byte slice" message
I use the pgx/sqlx combination, PostgreSQL 11.5